### PR TITLE
Sort, then render the record of the swaps

### DIFF
--- a/CC_QuickSort/CC_QuickSort.pde
+++ b/CC_QuickSort/CC_QuickSort.pde
@@ -1,90 +1,190 @@
+/*
+ * Stephen Stafford - September 2018 <clothcat @ gmail.com>
+ */
 
-float[] values;
+import java.util.Arrays;
 
+/** 
+ * Array to hold the original (unsorted) array - once generated this is left 
+ * untouched as a reference.  We need to keep a copy of the original array
+ * because we're going to first sort it (recording the swaps as we go) and 
+ * then rerun the same swaps whillst rendering for visualisation.
+ * this requires us to be able to get back to the original array
+ */
+float[] unsortedArray;
+
+/** 
+ * The array we're going to actually sort.  This will start out as a copy of the 
+ * unsorted array.
+ */
+float[] beingSortedArray;
+
+/** 
+ * The record of which items we swapped as we sorted the array.  This is
+ * an ArrayList rather than an array because an ArrayList will grow silently
+ * as we add items to it (similarly to a Javastrint array) and we don't know
+ * in advance how many swaps will be required to sort the array.
+ */
+ArrayList<Swap> swaps;
+
+/** Counter to keep track of which step we're looking at whilst rendering the sort */
+int swapStep = 0;
+
+/** 
+ * The number of swaps to do on each render interation (basically governs how 
+ * fast the render happens.
+ */
+int swapsPerFrame = 3;
+
+/** Processing setup method */
 void setup() {
-  size(600, 400);
-  values = new float[width];
-  for (int i = 0; i < values.length; i++) {
-    values[i] = random(height);
-  }
+  size(1600, 700);
+  // stop drawing until AFTER we've initially sorted the array
   noLoop();
-}
-void quicksort(float[] arr, int lo, int hi) {
-  if (lo < hi) {
-    int mid = partition(arr, lo, hi);
-    quicksort(arr, lo, mid-1);    
-    quicksort(arr, mid+1, hi);
-  }
-}
+  // create the randomised unsorteed array - this array is NOT manipulated
+  // but remains untouched as a reference array.
+  unsortedArray = makeUnsortedArray(width, height);
+  // copy the unsorted array into beingSortedArray
+  beingSortedArray = Arrays.copyOf(unsortedArray, unsortedArray.length);
+  // sort the array recording the steps as we go along
+  swaps = new ArrayList<Swap>();
+  quicksortWithRecord(beingSortedArray, 0, beingSortedArray.length-1, swaps);
 
-// Working partition code from:
-// https://www.geeksforgeeks.org/quick-sort/
-
-//int partition (float arr[], int low, int high) {
-//  float pivot = arr[high];  
-//  int i = (low - 1);  
-//  for (int j = low; j <= high- 1; j++) {
-//    if (arr[j] <= pivot) {
-//      i++;
-//      swap(arr, i, j);
-//    }
-//  }
-//  swap(arr, i+1, high);
-//  return (i + 1);
-//}
-
-void mousePressed() {
-  quicksort(values, 0, values.length-1);
+  // reset for drawing
+  beingSortedArray = Arrays.copyOf(unsortedArray, unsortedArray.length);
+  // start drawing now that everything is ready.
+  loop();
 }
 
+/** Processing draw method */
 void draw() {
-  render();
-  println("Help");
-}
-
-// Broken partition code that I tried to write
-// TODO: Help!
-int partition(float[] arr, int lo, int hi) {
-  //println("Partition " + lo + " to " + hi);
-  float pivot = arr[hi];
-  int left = lo-1;
-  int right = hi-1;
-
-  while (left <= right) {
-    left++;
-    println(left, right);
-    if (arr[left] >= pivot) {
-      while (right > left) {
-        if (arr[right] < pivot) {
-          swap(arr, left, right);
-          break;
-        }
-        right--;
-      }
+  for (int i=0; i<swapsPerFrame; i++) {
+    // advance the sort by one step
+    Swap swap = swaps.get(swapStep);
+    swapArrayElements(beingSortedArray, swap.a, swap.b);
+    
+    // ready for the next step
+    swapStep++;
+    // check we won't go past the end of the array
+    if(swapStep>=swaps.size()){
+      break;
     }
   }
+  // draw the result
+  render(beingSortedArray);
 
-  if (left < hi-1) {
-    swap(arr, left, hi);
+  // stop if we've finished
+  if (swapStep >= swaps.size()) {
+    noLoop();
+    System.out.println("Finished");
   }
-  println("Mid: "+ left);
-  return left;
 }
 
+/**
+ * run the Quicksort algorithm recording the steps as we go.
+ *
+ * This code is (almost exactly) the same as Dan's.
+ */
+void quicksortWithRecord(float[] arr, int lo, int hi, ArrayList<Swap> swapRecord) {
+  if (lo < hi) {
+    int mid = partitionWithRecord(arr, lo, hi, swapRecord);
+    quicksortWithRecord(arr, lo, mid-1, swapRecord);    
+    quicksortWithRecord(arr, mid+1, hi, swapRecord);
+  }
+}
 
-void render() {
+/** 
+ * Partition the array between lo and hi recording the swaps as we go.
+ *
+ * This code is almost exactly the same as Dan's.
+ */
+int partitionWithRecord (float arr[], int low, int high, ArrayList<Swap> swapRecord) {
+  float pivot = arr[high];  
+  int i = (low - 1);  
+  for (int j = low; j <= high- 1; j++) {
+    if (arr[j] <= pivot) {
+      i++;
+      recordedSwapArrayElements(arr, i, j, swapRecord);
+    }
+  }
+  recordedSwapArrayElements(arr, i+1, high, swapRecord);
+  return (i + 1);
+}
+
+/** 
+ * Method to draw the given array on the screen.
+ * THis code is directly copied from Dan's.
+ */
+void render(float[] arr) {
   background(0);
-  for (int i = 0; i < values.length; i++) {
+  for (int i = 0; i < arr.length; i++) {
     stroke(255);
-    line(i, height, i, height - values[i]);
+    line(i, height, i, height - arr[i]);
   }
 }
 
-void swap(float[] arr, int a, int b) {
+/** 
+ * Generate an array of the specified size with values which range 
+ * linearly from 0 to the specified maxValue.  We could just stick 
+ * random numbers in here, but there's something pleasing to my OCD 
+ * if the sorted array is a straight line...
+ * 
+ * @param arraySize the size of the array to create
+ * @param maxValue the maximum value of the array to create
+ */
+float[] makeUnsortedArray(int arraySize, int maxValue) {
+  float[] arr = new float[arraySize];
+  for (int i=0; i<arr.length; i++) {
+    arr[i] = map(i, 0, arr.length, 0, maxValue);
+  }
+  shuffle(arr);
+  return arr;
+}
+
+/** 
+ * Performs an in-place shuffle of the elements of the passed array using
+ * the Fisher-Yates algorithm (which gives a slightly more uniform distribution
+ * than the naive shuffle).
+ * 
+ * @see https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle 
+ *
+ * @param arr the array to shuffle 
+ */
+void shuffle(float[] arr) {
+  for (int i=arr.length-1; i>0; i--) {
+    int j = floor(random(0, i));
+    swapArrayElements(arr, i, j);
+  }
+}
+
+/** Swap in place two elements of a given array */
+void swapArrayElements(float[] arr, int a, int b) {
   float temp = arr[a];
   arr[a] = arr[b];
   arr[b] = temp;
+}
 
+/**
+ * swap two elements of an array and record which elements were swapped in an 
+ * ArrayList of {@link Swap}
+ */
+void recordedSwapArrayElements(float[] arr, int a, int b, ArrayList<Swap> swapRecord) {
+  Swap swap = new Swap(a, b);
+  swapRecord.add(swap);
+  swapArrayElements(arr, a, b);
+}
 
-  redraw();
+/** Simple class to hold the two indices of a swap in an array */
+class Swap {
+  int a, b;
+  Swap(int a, int b) {
+    this.a=a;
+    this.b=b;
+  }
+
+  /** toString method, handy for debugging with println statements */
+  @Override
+    public String toString() {
+    return String.format("[%d, %d]", a, b);
+  }
 }


### PR DESCRIPTION
Rather than trying to render as we're sorting (possible, but irritating) we do the sort first and keep a record of the swaps made, and then render it by redoing the swaps.

Probably not really what Dan was looking for (I've ignored his broken partition mechanism because I just found it ugly compared to the standard way and didn't want to be caring about it :))

Note: this algorithm/implementation does a LOT of needless swaps (basically swaps elements with themselves) - I believe I could basically double the rendering speed by first filtering out those swaps.  Not sure if you ever use any Java8 constructs though (never seen you doing so).

Nice idea I probably won't have time/inclination to do: 
Instead of just shuffling white lines, make them strips of a photograph instead, so now you can watch a picture get sorted...

Something I might do if I get the time:
Extend this slightly so that you can easily plug in different sort algorithms.  The only stuff that really cares about the swap record are the swap function itself and the rendering.  With just a little tidying up, as long as the sort is swap based, this is easy, so perhaps out-of-place-mergesort would be tricky to  render, but basically anything that does the sort in-place would be easy.